### PR TITLE
return Unknown instead of Internal

### DIFF
--- a/server/server.go
+++ b/server/server.go
@@ -302,7 +302,7 @@ func (s *server) createSession(db *database, dbName string) (*session, error) {
 		return session, nil
 	}
 
-	return nil, status.Errorf(codes.Internal, "create session failed")
+	return nil, status.Errorf(codes.Unknown, "create session failed")
 }
 
 func (s *server) createDatabase(name string) (*database, error) {
@@ -376,7 +376,7 @@ func (s *server) dropDatabase(name string) error {
 	}
 
 	if err := db.Close(); err != nil {
-		return status.Errorf(codes.Internal, "Failed to close the database: %s", err)
+		return status.Errorf(codes.Unknown, "Failed to close the database: %s", err)
 	}
 
 	s.dbMu.Lock()


### PR DESCRIPTION
google-cloud-go implicitly retries some requests when the response is Internal. handy-spanner returns Internal error for now if there is unexpected error or unimplemented features. As the result, client retries forever.

This PR fixes not to retry internal errors for handy-spanner.