### PR TITLE
More support for KeyRange works

### DIFF
--- a/server/database_test.go
+++ b/server/database_test.go
@@ -804,6 +804,24 @@ func TestRead(t *testing.T) {
 				[]interface{}{int64(300), "zzz"},
 			},
 		},
+		"Simple_KeyRange_OpenClose2": {
+			tbl:  "CompositePrimaryKeys",
+			cols: []string{"Id", "PKey1", "PKey2"},
+			ks: &KeySet{
+				Ranges: []*KeyRange{
+					{
+						start:       makeListValue(makeStringValue("bbb"), makeStringValue("3")),
+						end:         makeListValue(makeStringValue("ccc"), makeStringValue("3")),
+						startClosed: false,
+						endClosed:   true,
+					},
+				},
+			},
+			limit: 100,
+			expected: [][]interface{}{
+				[]interface{}{int64(4), "ccc", int64(3)},
+			},
+		},
 		"Simple_KeyRange_CloseOpen": {
 			tbl:  "Simple",
 			cols: []string{"Id", "Value"},
@@ -839,6 +857,98 @@ func TestRead(t *testing.T) {
 			limit: 100,
 			expected: [][]interface{}{
 				[]interface{}{int64(200), "yyy"},
+			},
+		},
+		"Simple_KeyRange_LessPrimaryKey": {
+			tbl:  "CompositePrimaryKeys",
+			cols: []string{"Id", "PKey1", "PKey2"},
+			ks: &KeySet{
+				Ranges: []*KeyRange{
+					{
+						start:       makeListValue(makeStringValue("bbb"), makeStringValue("2")),
+						end:         makeListValue(makeStringValue("bbb")),
+						startClosed: true,
+						endClosed:   true,
+					},
+				},
+			},
+			limit: 100,
+			expected: [][]interface{}{
+				[]interface{}{int64(3), "bbb", int64(3)},
+				[]interface{}{int64(2), "bbb", int64(2)},
+			},
+		},
+		"Simple_KeyRange_LessPrimaryKey2": {
+			tbl:  "CompositePrimaryKeys",
+			cols: []string{"Id", "PKey1", "PKey2"},
+			ks: &KeySet{
+				Ranges: []*KeyRange{
+					{
+						start:       makeListValue(makeStringValue("bbb")),
+						end:         makeListValue(makeStringValue("bbb"), makeStringValue("3")),
+						startClosed: true,
+						endClosed:   true,
+					},
+				},
+			},
+			limit: 100,
+			expected: [][]interface{}{
+				[]interface{}{int64(3), "bbb", int64(3)},
+				[]interface{}{int64(2), "bbb", int64(2)},
+			},
+		},
+		"Simple_KeyRange_LessPrimaryKey3": {
+			tbl:  "CompositePrimaryKeys",
+			cols: []string{"Id", "PKey1", "PKey2"},
+			ks: &KeySet{
+				Ranges: []*KeyRange{
+					{
+						start:       makeListValue(makeStringValue("bbb")),
+						end:         makeListValue(makeStringValue("bbb")),
+						startClosed: true,
+						endClosed:   true,
+					},
+				},
+			},
+			expected: [][]interface{}{
+				[]interface{}{int64(3), "bbb", int64(3)},
+				[]interface{}{int64(2), "bbb", int64(2)},
+			},
+		},
+		"Simple_KeyRange_LessPrimaryKeyOpenClosed": {
+			tbl:  "CompositePrimaryKeys",
+			cols: []string{"Id", "PKey1", "PKey2"},
+			ks: &KeySet{
+				Ranges: []*KeyRange{
+					{
+						start:       makeListValue(makeStringValue("bbb"), makeStringValue("2")),
+						end:         makeListValue(makeStringValue("bbb")),
+						startClosed: false,
+						endClosed:   true,
+					},
+				},
+			},
+			limit: 100,
+			expected: [][]interface{}{
+				[]interface{}{int64(3), "bbb", int64(3)},
+			},
+		},
+		"Simple_KeyRange_LessPrimaryKeyClosedOpen": {
+			tbl:  "CompositePrimaryKeys",
+			cols: []string{"Id", "PKey1", "PKey2"},
+			ks: &KeySet{
+				Ranges: []*KeyRange{
+					{
+						start:       makeListValue(makeStringValue("bbb")),
+						end:         makeListValue(makeStringValue("bbb"), makeStringValue("3")),
+						startClosed: true,
+						endClosed:   false,
+					},
+				},
+			},
+			limit: 100,
+			expected: [][]interface{}{
+				[]interface{}{int64(2), "bbb", int64(2)},
 			},
 		},
 

--- a/server/value.go
+++ b/server/value.go
@@ -590,14 +590,14 @@ func (it *rows) next() ([]interface{}, bool) {
 }
 
 func convertToDatabaseValues(lv *structpb.ListValue, columns []*Column) ([]interface{}, error) {
-	values := make([]interface{}, len(columns))
+	values := make([]interface{}, 0, len(columns))
 	for i, v := range lv.Values {
 		column := columns[i]
 		vv, err := spannerValue2DatabaseValue(v, *column)
 		if err != nil {
 			return nil, status.Errorf(codes.InvalidArgument, "%v", err)
 		}
-		values[i] = vv
+		values = append(values, vv)
 	}
 	return values, nil
 }


### PR DESCRIPTION
I tried to use `spanner.Key{...}.AsPrefix()` to retrieve some records by one primary key, but I got the following error.

```
panic: spanner: code = "InvalidArgument", desc = "TODO: invalid start range key"
```

Reproduction code is below.

```go
package main

import (
	"context"
	"fmt"
	"strings"

	"cloud.google.com/go/spanner"
	"github.com/gcpug/handy-spanner/fake"
	"google.golang.org/api/option"
)

func main() {
	dbName := "projects/fake/instances/fake/databases/fake"
	srv, conn, err := fake.Run()
	if err != nil {
		panic(err)
	}
	defer srv.Stop()
	defer conn.Close()

	ctx := context.Background()
	if err := srv.ParseAndApplyDDL(context.Background(), dbName, strings.NewReader(strings.Join([]string{
		"CREATE TABLE Table1 (",
		"  Key STRING(MAX) NOT NULL,",
		"  User STRING(MAX) NOT NULL",
		") PRIMARY KEY (Key, User)",
	}, "\n"))); err != nil {
		panic(err)
	}
	client, err := spanner.NewClient(ctx, dbName, option.WithGRPCConn(conn))
	if err != nil {
		panic(err)
	}
	if _, err := client.Apply(context.Background(), []*spanner.Mutation{
		spanner.Insert("Table1", []string{"Key", "User"}, []interface{}{"key1", "user1"}),
	}); err != nil {
		panic(err)
	}
	keys := spanner.KeySets(spanner.Key{"key1"}.AsPrefix())
	rows := client.Single().Read(context.Background(), "Table1", keys, []string{"Key", "User"})
	if err := rows.Do(func(r *spanner.Row) error {
		fmt.Printf("%+v\n", r)
		return nil
	}); err != nil {
		panic(err)
	}
}
```

handy-spanner does not seem to implement some behavior of KeyRange.

https://godoc.org/cloud.google.com/go/spanner#KeyRange

This pull-request implements some behavior of KeyRange.

However, I don't implement entirely. For example, the below is not implemented because I have no idea how to implement this behavior on SQLite and SQL.

> This range returns all users whose UserName begins with any character from A to C:

```go
spanner.KeyRange{
	Start: spanner.Key{"A"},
	End:   spanner.Key{"D"},
}
```

Please let me know if you have any idea of that.