### PR TITLE
Using alias with specialTable

### DIFF
--- a/server/database_test.go
+++ b/server/database_test.go
@@ -3920,6 +3920,13 @@ func TestInformationSchema(t *testing.T) {
 				{"", "", "Simple", "PRIMARY_KEY", "PRIMARY_KEY", "Id", int64(1), "ASC", "NO", "INT64"},
 			},
 		},
+		{
+			name: "IndexColumns_WithAlias",
+			sql:  `SELECT COLUMN_NAME FROM INFORMATION_SCHEMA.INDEX_COLUMNS a WHERE a.TABLE_NAME = "Simple"`,
+			expected: [][]interface{}{
+				[]interface{}{"Id"},
+			},
+		},
 	}
 
 	for _, tc := range table {

--- a/server/query.go
+++ b/server/query.go
@@ -619,6 +619,7 @@ func (b *QueryBuilder) buildQueryTable(exp ast.TableExpr) (*TableView, string, [
 			if specialTableName, ok := metaTablesMap[tableName]; ok {
 				return b.buildQueryTable(&ast.TableName{
 					Table: &ast.Ident{Name: specialTableName},
+					As:    src.As,
 				})
 			}
 		}


### PR DESCRIPTION
This PR fixes the error: `Query failed: *ast.Path: Unrecognized name: a` on using alias with special table.