### PR TITLE
QueryBuilder supports a where clause that omits table schema for special tables

### DIFF
--- a/server/database_test.go
+++ b/server/database_test.go
@@ -3927,6 +3927,27 @@ func TestInformationSchema(t *testing.T) {
 				[]interface{}{"Id"},
 			},
 		},
+		{
+			name: "IndexColumns_WithOmittedSchema",
+			sql:  `SELECT COLUMN_NAME FROM INFORMATION_SCHEMA.INDEX_COLUMNS WHERE INDEX_COLUMNS.TABLE_NAME = "Simple"`,
+			expected: [][]interface{}{
+				[]interface{}{"Id"},
+			},
+		},
+		{
+			name: "IndexColumns_WithJoin",
+			sql:  `SELECT COLUMN_NAME FROM INFORMATION_SCHEMA.INDEX_COLUMNS LEFT JOIN INFORMATION_SCHEMA.INDEXES ON INDEX_COLUMNS.TABLE_NAME = INDEXES.TABLE_NAME WHERE INDEX_COLUMNS.TABLE_NAME = "Simple"`,
+			expected: [][]interface{}{
+				[]interface{}{"Id"},
+			},
+		},
+		{
+			name: "IndexColumns_WithUsingJoin",
+			sql:  `SELECT COLUMN_NAME FROM INFORMATION_SCHEMA.INDEX_COLUMNS LEFT JOIN INFORMATION_SCHEMA.INDEXES USING(TABLE_NAME) WHERE INDEX_COLUMNS.TABLE_NAME = "Simple"`,
+			expected: [][]interface{}{
+				[]interface{}{"Id"},
+			},
+		},
 	}
 
 	for _, tc := range table {

--- a/server/query.go
+++ b/server/query.go
@@ -592,8 +592,11 @@ func (b *QueryBuilder) buildQueryTable(exp ast.TableExpr) (*TableView, string, [
 		query := QuoteString(t.Name)
 		alias := t.Name
 		if src.As != nil {
-			query = fmt.Sprintf("%s AS %s", QuoteString(t.Name), QuoteString(src.As.Alias.Name))
 			alias = src.As.Alias.Name
+			query = fmt.Sprintf("%s AS %s", QuoteString(t.Name), QuoteString(alias))
+		} else if schema, ok := metaTablesReverseMap[t.Name]; ok {
+			alias = schema[1]
+			query = fmt.Sprintf("%s AS %s", QuoteString(t.Name), QuoteString(alias))
 		}
 
 		view := t.TableViewWithAlias(alias)


### PR DESCRIPTION
This PR enables queries with omitted schema name of special tables as follows.

```sql
SELECT COLUMN_NAME FROM INFORMATION_SCHEMA.INDEX_COLUMNS LEFT JOIN INFORMATION_SCHEMA.INDEXES ON INDEX_COLUMNS.TABLE_NAME = INDEXES.TABLE_NAME WHERE INDEX_COLUMNS.TABLE_NAME = "Simple"
```