### PR TITLE
fix key range order

### DIFF
--- a/fake/testdata/schema.sql
+++ b/fake/testdata/schema.sql
@@ -35,8 +35,9 @@ CREATE TABLE FullTypes (
 ) PRIMARY KEY(PKey);
 
 CREATE UNIQUE INDEX FullTypesByFTString ON FullTypes(FTString);
-CREATE UNIQUE INDEX FullTypesByIntDate ON FullTypes(FTInt, FTDate);
+CREATE INDEX FullTypesByIntDate ON FullTypes(FTInt, FTDate);
 CREATE INDEX FullTypesByIntTimestamp ON FullTypes(FTInt, FTTimestamp);
+CREATE INDEX FullTypesByIntTimestampReverse ON FullTypes(FTInt, FTTimestamp DESC);
 CREATE INDEX FullTypesByTimestamp ON FullTypes(FTTimestamp);
 
 CREATE TABLE ArrayTypes (

--- a/server/database.go
+++ b/server/database.go
@@ -595,7 +595,7 @@ func (d *database) Read(ctx context.Context, tx *transaction, tbl, idx string, c
 
 	var args []interface{}
 
-	whereClause, whereArgs, err := buildWhereClauseFromKeySet(keyset, indexColumnsName, indexColumns)
+	whereClause, whereArgs, err := buildWhereClauseFromKeySet(keyset, indexColumnsName, indexColumns, indexColumnDirs)
 	if err != nil {
 		return nil, err
 	}
@@ -1001,8 +1001,9 @@ func (d *database) Delete(ctx context.Context, tx *transaction, tbl string, keys
 
 	indexColumnsName := strings.Join(QuoteStringSlice(index.IndexColumnNames()), ", ")
 	indexColumns := index.IndexColumns()
+	indexColumnDirs := index.IndexColumnDirections()
 
-	whereClause, args, err := buildWhereClauseFromKeySet(keyset, indexColumnsName, indexColumns)
+	whereClause, args, err := buildWhereClauseFromKeySet(keyset, indexColumnsName, indexColumns, indexColumnDirs)
 	if err != nil {
 		return err
 	}

--- a/server/database_test.go
+++ b/server/database_test.go
@@ -875,7 +875,6 @@ func TestRead(t *testing.T) {
 			},
 			limit: 100,
 			expected: [][]interface{}{
-				[]interface{}{int64(3), "bbb", int64(3)},
 				[]interface{}{int64(2), "bbb", int64(2)},
 			},
 		},
@@ -895,7 +894,6 @@ func TestRead(t *testing.T) {
 			limit: 100,
 			expected: [][]interface{}{
 				[]interface{}{int64(3), "bbb", int64(3)},
-				[]interface{}{int64(2), "bbb", int64(2)},
 			},
 		},
 		"Simple_KeyRange_LessPrimaryKey3": {
@@ -929,10 +927,8 @@ func TestRead(t *testing.T) {
 					},
 				},
 			},
-			limit: 100,
-			expected: [][]interface{}{
-				[]interface{}{int64(3), "bbb", int64(3)},
-			},
+			limit:    100,
+			expected: nil,
 		},
 		"Simple_KeyRange_LessPrimaryKeyClosedOpen": {
 			tbl:  "CompositePrimaryKeys",
@@ -947,10 +943,8 @@ func TestRead(t *testing.T) {
 					},
 				},
 			},
-			limit: 100,
-			expected: [][]interface{}{
-				[]interface{}{int64(2), "bbb", int64(2)},
-			},
+			limit:    100,
+			expected: nil,
 		},
 
 		// Composite Keys
@@ -1009,14 +1003,14 @@ func TestRead(t *testing.T) {
 			ks: &KeySet{
 				Ranges: []*KeyRange{
 					{
-						start:       makeListValue(makeStringValue("bbb"), makeStringValue("2")),
-						end:         makeListValue(makeStringValue("bbb"), makeStringValue("3")),
+						start:       makeListValue(makeStringValue("bbb"), makeStringValue("3")),
+						end:         makeListValue(makeStringValue("bbb"), makeStringValue("2")),
 						startClosed: true,
 						endClosed:   true,
 					},
 					{
-						start:       makeListValue(makeStringValue("ccc"), makeStringValue("3")),
-						end:         makeListValue(makeStringValue("ccc"), makeStringValue("4")),
+						start:       makeListValue(makeStringValue("ccc"), makeStringValue("4")),
+						end:         makeListValue(makeStringValue("ccc"), makeStringValue("3")),
 						startClosed: true,
 						endClosed:   true,
 					},
@@ -1041,8 +1035,8 @@ func TestRead(t *testing.T) {
 				},
 				Ranges: []*KeyRange{
 					{
-						start:       makeListValue(makeStringValue("bbb"), makeStringValue("2")),
-						end:         makeListValue(makeStringValue("bbb"), makeStringValue("3")),
+						start:       makeListValue(makeStringValue("bbb"), makeStringValue("3")),
+						end:         makeListValue(makeStringValue("bbb"), makeStringValue("2")),
 						startClosed: true,
 						endClosed:   true,
 					},
@@ -2463,8 +2457,8 @@ func TestDelete(t *testing.T) {
 			ks: &KeySet{
 				Ranges: []*KeyRange{
 					{
-						start:       makeListValue(makeStringValue("bbb"), makeStringValue("1")),
-						end:         makeListValue(makeStringValue("bbb"), makeStringValue("4")),
+						start:       makeListValue(makeStringValue("bbb"), makeStringValue("4")),
+						end:         makeListValue(makeStringValue("bbb"), makeStringValue("1")),
 						startClosed: true,
 						endClosed:   true,
 					},


### PR DESCRIPTION
There a bug for KeyRange for Read API if the index uses a descending column.