### PR TITLE
return error details such as ResourceInfo with error

### DIFF
--- a/server/server.go
+++ b/server/server.go
@@ -284,7 +284,7 @@ func (s *server) getSession(name string) (*session, error) {
 	}
 	session, ok := s.sessions[name]
 	if !ok {
-		return nil, status.Errorf(codes.NotFound, "Session not found: %s", name)
+		return nil, newSpannerSessionNotFoundError(name)
 	}
 	return session, nil
 }
@@ -339,7 +339,7 @@ func (s *server) getOrCreateDatabase(name string) (*database, error) {
 	s.dbMu.RUnlock()
 	if !ok {
 		if !s.autoCreateDatabase {
-			return nil, status.Errorf(codes.NotFound, "Database not found: %s", name)
+			return nil, newSpannerDatabaseNotFoundError(name)
 		}
 
 		var err error
@@ -357,7 +357,7 @@ func (s *server) getDatabase(name string) (*database, error) {
 	db, ok := s.db[name]
 	s.dbMu.RUnlock()
 	if !ok {
-		return nil, status.Errorf(codes.NotFound, "Database not found: %s", name)
+		return nil, newSpannerDatabaseNotFoundError(name)
 	}
 
 	return db, nil

--- a/server/spanner_error.go
+++ b/server/spanner_error.go
@@ -1,0 +1,93 @@
+// Copyright 2020 Masahiro Sano
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package server
+
+import (
+	"fmt"
+
+	"google.golang.org/genproto/googleapis/rpc/errdetails"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+func newSpannerDatabaseNotFoundError(name string) error {
+	detail := &errdetails.ResourceInfo{
+		ResourceType: "type.googleapis.com/google.spanner.admin.database.v1.Database",
+		ResourceName: name,
+		Description:  "Database does not exist.",
+	}
+	st, err := status.Newf(codes.NotFound, "Database not found: %s", name).WithDetails(detail)
+	if err != nil {
+		return status.Errorf(codes.Internal, "failed to build status error")
+	}
+
+	return st.Err()
+}
+
+func newSpannerSessionNotFoundError(name string) error {
+	detail := &errdetails.ResourceInfo{
+		ResourceType: "type.googleapis.com/google.spanner.v1.Session",
+		ResourceName: name,
+		Description:  "Session does not exist.",
+	}
+	st, err := status.Newf(codes.NotFound, "Session not found: %s", name).WithDetails(detail)
+	if err != nil {
+		return status.Errorf(codes.Internal, "failed to build status error")
+	}
+
+	return st.Err()
+}
+
+func newSpannerTableNotFoundError(name string) error {
+	detail := &errdetails.ResourceInfo{
+		ResourceType: "spanner.googleapis.com/Table",
+		ResourceName: name,
+		Description:  "Table not found",
+	}
+	st, err := status.Newf(codes.NotFound, "Table not found: %s", name).WithDetails(detail)
+	if err != nil {
+		return status.Errorf(codes.Internal, "failed to build status error")
+	}
+
+	return st.Err()
+}
+
+func newSpannerColumnNotFoundError(table, name string) error {
+	detail := &errdetails.ResourceInfo{
+		ResourceType: "spanner.googleapis.com/Column",
+		ResourceName: name,
+		// no description in real spanner
+	}
+	st, err := status.Newf(codes.NotFound, "Column not found in table %s: %s", table, name).WithDetails(detail)
+	if err != nil {
+		return status.Errorf(codes.Internal, "failed to build status error")
+	}
+
+	return st.Err()
+}
+
+func newSpannerIndexnNotFoundError(table, name string) error {
+	detail := &errdetails.ResourceInfo{
+		ResourceType: "spanner.googleapis.com/Index",
+		ResourceName: name,
+		Description:  fmt.Sprintf("Index not found on table %s", table),
+	}
+	st, err := status.Newf(codes.NotFound, "Index not found on table %s: %s", table, name).WithDetails(detail)
+	if err != nil {
+		return status.Errorf(codes.Internal, "failed to build status error")
+	}
+
+	return st.Err()
+}

--- a/server/table.go
+++ b/server/table.go
@@ -142,7 +142,7 @@ func (t *Table) createIndex(stmt *ast.CreateIndex) (*TableIndex, error) {
 func (t *Table) getColumn(name string) (*Column, error) {
 	c, ok := t.columnsMap[name]
 	if !ok {
-		return nil, fmt.Errorf("Column not found: %s", name)
+		return nil, newSpannerColumnNotFoundError(t.Name, name)
 	}
 	return c, nil
 }
@@ -150,9 +150,9 @@ func (t *Table) getColumn(name string) (*Column, error) {
 func (t *Table) getColumnsByName(names []string) ([]*Column, error) {
 	columns := make([]*Column, len(names))
 	for i, name := range names {
-		c, ok := t.columnsMap[name]
-		if !ok {
-			return nil, fmt.Errorf("Column not found: %s", name)
+		c, err := t.getColumn(name)
+		if err != nil {
+			return nil, err
 		}
 		columns[i] = c
 	}


### PR DESCRIPTION
google-cloud-go uses ResourceInfo for error handling. It's also useful for application code if ResourceInfo is attached in error.