### PR TITLE
add note about "json1" build tag to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@
 go get github.com/gcpug/handy-spanner/cmd/handy-spanner
 ```
 
+NOTE: If you want to use some features (e.g. array literal `[]` in DML), require "json1" build tag.
 The Spanner emulator uses sqlite3 internally. You may need to build go-sqlite3 explicitly.
 It also requires cgo to use sqlite3.
 


### PR DESCRIPTION
SSIA.
When used `[]` without this tag, panic occurs internally.
(In my environment, handy-spanner is working on docker. Panic immediately causes shutting down of container, a bit hard to investigate this behavior.)
