### PR TITLE
Add metadata to LongRunningOperation response

### DIFF
--- a/server/server.go
+++ b/server/server.go
@@ -223,8 +223,9 @@ func (s *server) GetOperation(ctx context.Context, req *lropb.GetOperationReques
 
 	any, _ := ptypes.MarshalAny(&empty.Empty{})
 	op := &lropb.Operation{
-		Name: "TODO:xxx",
-		Done: true,
+		Name:     "TODO:xxx",
+		Metadata: any,
+		Done:     true,
 		Result: &lropb.Operation_Response{
 			Response: any,
 		},
@@ -247,8 +248,9 @@ func (s *server) WaitOperation(ctx context.Context, req *lropb.WaitOperationRequ
 	}
 	any, _ := ptypes.MarshalAny(&empty.Empty{})
 	op := &lropb.Operation{
-		Name: "TODO:xxx",
-		Done: true,
+		Name:     "TODO:xxx",
+		Metadata: any,
+		Done:     true,
 		Result: &lropb.Operation_Response{
 			Response: any,
 		},

--- a/server/server.go
+++ b/server/server.go
@@ -116,8 +116,9 @@ func (s *server) CreateDatabase(ctx context.Context, req *adminv1pb.CreateDataba
 		State: adminv1pb.Database_READY,
 	})
 	op := &lropb.Operation{
-		Name: fmt.Sprintf("%s/operations/_auto_%d", databaseName, time.Now().UnixNano()/1000),
-		Done: true,
+		Name:     fmt.Sprintf("%s/operations/_auto_%d", databaseName, time.Now().UnixNano()/1000),
+		Metadata: resp,
+		Done:     true,
 		Result: &lropb.Operation_Response{
 			Response: resp,
 		},


### PR DESCRIPTION
The PHP Spanner client requires LongRunningResponse::metadata for CreateDatabase.

ref: https://github.com/googleapis/google-cloud-php/pull/2536

> now, if operation isDone and response is present obtains response typeUrl from $response['response']['typeUrl'] and deserializes the response.
always also obtains metadata typeUrl from $response['metadata']['typeUrl'] and deserializes the metadata.