### PR TITLE
fix(README.md): Usage instruction

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ go install github.com/mattn/go-sqlite3
 or
 
 ```
-docker run --rm -it -p 9999:9999 handy-spanner
+docker run --rm -it -p 9999:9999 ginco/handy-spanner
 ```
 
 It runs a hand-spanner server as a process. It serves spanner gRPC server by port 9999 by default.


### PR DESCRIPTION
`handy-spanner` is not identified. 
```sh
mac@mac ~ % docker run --rm -it -p 9999:9999 handy-spanner
Unable to find image 'handy-spanner:latest' locally
docker: Error response from daemon: pull access denied for handy-spanner, repository does not exist or may require 'docker login': denied: requested access to the resource is denied.
```

ginco/handy-spanner should be used.

```sh
mac@mac ~ % docker run --rm -it -p 9999:9999 ginco/handy-spanner
Unable to find image 'ginco/handy-spanner:latest' locally
latest: Pulling from ginco/handy-spanner
4167d3e14976: Pull complete 
6861f8c2aa25: Pull complete 
bc1d6e964f35: Pull complete 
Digest: sha256:0137ba450934957b5fd8f91dd12152e6ddc365f51d282cfbc41edc2f2f723c09
Status: Downloaded newer image for ginco/handy-spanner:latest
2021/08/17 20:56:39 spanner server is ready
```
