### PR TITLE
Support non-nullable generated column

### DIFF
--- a/server/database.go
+++ b/server/database.go
@@ -762,7 +762,7 @@ func (d *database) write(ctx context.Context, tx *transaction, tbl string, cols 
 
 	// Check not nullable columns are specified for Insert/Replace
 	if nonNullCheck {
-		if exist, nonNullables := table.NonNullableColumnsExist(cols); exist {
+		if exist, nonNullables := table.NonNullableAndNonGeneratedColumnsExist(cols); exist {
 			columns := strings.Join(nonNullables, ", ")
 			return status.Errorf(codes.FailedPrecondition,
 				"A new row in table %s does not specify a non-null value for these NOT NULL columns: %s",

--- a/server/query.go
+++ b/server/query.go
@@ -480,7 +480,7 @@ func (b *QueryBuilder) buildInsert(up *ast.Insert) (string, []interface{}, error
 	}
 
 	// Check not nullable columns
-	if exist, nonNullables := t.NonNullableColumnsExist(columns); exist {
+	if exist, nonNullables := t.NonNullableAndNonGeneratedColumnsExist(columns); exist {
 		columns := strings.Join(nonNullables, ", ")
 		return "", nil, status.Errorf(codes.FailedPrecondition,
 			"A new row in table %s does not specify a non-null value for these NOT NULL columns: %s",

--- a/server/table.go
+++ b/server/table.go
@@ -68,7 +68,7 @@ func (t *Table) NonNullableAndNonGeneratedColumnsExist(columns []string) (bool, 
 		usedColumns[name] = struct{}{}
 	}
 
-	var noExsitNonNullableColumns []string
+	var noExistNonNullableColumns []string
 	for _, c := range t.columns {
 		if c.nullable {
 			continue
@@ -79,12 +79,12 @@ func (t *Table) NonNullableAndNonGeneratedColumnsExist(columns []string) (bool, 
 
 		n := c.Name()
 		if _, ok := usedColumns[n]; !ok {
-			noExsitNonNullableColumns = append(noExsitNonNullableColumns, n)
+			noExistNonNullableColumns = append(noExistNonNullableColumns, n)
 		}
 	}
 
-	if len(noExsitNonNullableColumns) > 0 {
-		return true, noExsitNonNullableColumns
+	if len(noExistNonNullableColumns) > 0 {
+		return true, noExistNonNullableColumns
 	}
 
 	return false, nil

--- a/server/table.go
+++ b/server/table.go
@@ -60,9 +60,9 @@ func (t *Table) TableViewWithAlias(alias string) *TableView {
 	return createTableViewFromTable(t, alias)
 }
 
-// NonNullableColumnsExist checks non nullable columns exist in the spciefied columns.
-// It returns true and the columns if non nullable columns exist.
-func (t *Table) NonNullableColumnsExist(columns []string) (bool, []string) {
+// NonNullableAndNonGeneratedColumnsExist checks non nullable columns exist in the spciefied columns.
+// It returns true and the columns if non nullable and non generated columns exist.
+func (t *Table) NonNullableAndNonGeneratedColumnsExist(columns []string) (bool, []string) {
 	usedColumns := make(map[string]struct{}, len(columns))
 	for _, name := range columns {
 		usedColumns[name] = struct{}{}
@@ -71,6 +71,9 @@ func (t *Table) NonNullableColumnsExist(columns []string) (bool, []string) {
 	var noExsitNonNullableColumns []string
 	for _, c := range t.columns {
 		if c.nullable {
+			continue
+		}
+		if c.ast != nil && c.ast.GeneratedExpr != nil {
 			continue
 		}
 


### PR DESCRIPTION
## WHAT
Add support for inserting into table contains non-nullable generated columns.

## WHY
Currently, handy-spanner gives an error if the inserting column is insufficient against the non-nullable columns
```console
% handy-spanner &
[1] 38441
2022/10/15 15:13:04 spanner server is ready

% SPANNER_EMULATOR_HOST=localhost:9999 spanner-cli -p fake -i fake -d fake
Connected.
spanner> CREATE TABLE foobar (
      ->   id INT64 NOT NULL,
      ->   value STRING(MAX) NOT NULL AS (CAST(id AS STRING)) STORED,
      -> ) PRIMARY KEY(id);
Query OK, 0 rows affected (0.01 sec)

spanner> INSERT INTO foobar (id) VALUES (1);
ERROR: spanner: code = "FailedPrecondition", desc = "A new row in table foobar does not specify a non-null value for these NOT NULL columns: value"
```

This PR allows to insert without specifying columns with non-nullable but generated.