### PR TITLE
Add: Support For JSON Type

### DIFF
--- a/server/table.go
+++ b/server/table.go
@@ -268,6 +268,8 @@ func newColumn(def *ast.ColumnDef) *Column {
 		dbdt = DBDTText
 	case TCArray:
 		dbdt = DBDTJson
+	case TCJson:
+		dbdt = DBDTJson
 	}
 
 	var allowCommitTimestamp bool
@@ -307,6 +309,8 @@ func astTypeToTypeCode(astTypeName ast.ScalarTypeName) TypeCode {
 		return TCDate
 	case ast.TimestampTypeName:
 		return TCTimestamp
+	case ast.ScalarTypeName("JSON"):
+		return TCJson
 	default:
 		panic("unknown type")
 	}

--- a/server/value.go
+++ b/server/value.go
@@ -228,6 +228,7 @@ const (
 	TCBytes
 	TCArray
 	TCStruct
+	TCJson
 )
 
 type ArrayValue interface {


### PR DESCRIPTION
We are using `handy-spanner` for writing our tests.

Spanner supports JSON column type, however the same is not supported by handy-spanner. 

We want to add support for JSON column type. It is a trivial change considering the fact that we already use JSON data type while saving an array.

Currently, `memefish` library doesn't provide a "JSON" ScalarTypeName and hence I had to use "JSON". I would like to understand a better way to do the same - maybe we can raise a PR in memefish but I have a feeling it might not be maintained since last update was made in April.