### PR TITLE
modify database ApplyDDL to skip CREATE CHANGE STREAM

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,7 +159,7 @@ You can also operate databases or instances as Cloud Spanner supports. Please al
 * Replace
    * wrong behavior on conflict
 * [Change Stream Schema](https://cloud.google.com/spanner/docs/change-streams)
-   * only can parse in [Database operations](#Database operations) with `schema` flag.
+   * only can parse in [Database operations](#Database-operations) with `schema` flag.
 
 ## Implementation
 

--- a/README.md
+++ b/README.md
@@ -158,6 +158,8 @@ You can also operate databases or instances as Cloud Spanner supports. Please al
    * Long running operations
 * Replace
    * wrong behavior on conflict
+* [Change Stream Schema](https://cloud.google.com/spanner/docs/change-streams)
+   * only can parse in [Database operations](#Database operations) with `schema` flag.
 
 ## Implementation
 

--- a/fake/testdata/schema.sql
+++ b/fake/testdata/schema.sql
@@ -50,3 +50,6 @@ CREATE TABLE ArrayTypes (
   ArrayFloat ARRAY<FLOAT64>,
   ArrayDate ARRAY<DATE>,
 ) PRIMARY KEY(Id);
+
+CREATE CHANGE STREAM EverythingStream
+  FOR ALL;

--- a/server/database.go
+++ b/server/database.go
@@ -541,6 +541,9 @@ func (d *database) ApplyDDL(ctx context.Context, ddl ast.DDL) error {
 	case *ast.AlterTable:
 		return status.Errorf(codes.Unimplemented, "Alter Table is not supported yet")
 
+	case *ast.CreateChangeStream:
+		// skip CreateChangeStream
+		return nil
 	default:
 		return status.Errorf(codes.Unknown, "unknown DDL statement: %v", val)
 	}

--- a/server/database_test.go
+++ b/server/database_test.go
@@ -35,7 +35,7 @@ import (
 )
 
 var (
-	allSchema    = []string{schemaSimple, schemaInterleaved, schemaInterleavedCascade, schemaInterleavedNoAction, schemaForeignCascade, schemaForeignNoAction, schemaCompositePrimaryKeys, schemaFullTypes, schemaArrayTypes, schemaJoinA, schemaJoinB, schemaFromTable, schemaGeneratedValues, schemaGeneratedColumn, schemaDefaultValues}
+	allSchema    = []string{schemaSimple, schemaInterleaved, schemaInterleavedCascade, schemaInterleavedNoAction, schemaForeignCascade, schemaForeignNoAction, schemaCompositePrimaryKeys, schemaFullTypes, schemaArrayTypes, schemaJoinA, schemaJoinB, schemaFromTable, schemaGeneratedValues, schemaGeneratedColumn, schemaDefaultValues, schemaChangeStream}
 	schemaSimple = `CREATE TABLE Simple (
   Id INT64 NOT NULL,
   Value STRING(MAX) NOT NULL,
@@ -195,6 +195,9 @@ CREATE INDEX FullTypesByTimestamp ON FullTypes(FTTimestamp);
 		) PRIMARY KEY(Id);
 `
 
+	schemaChangeStream = `CREATE CHANGE STREAM EverythingStream
+  FOR ALL;
+`
 	compositePrimaryKeysKeys = []string{
 		"Id", "PKey1", "PKey2", "Error", "X", "Y", "Z",
 	}
@@ -638,6 +641,9 @@ func TestApplyDDL(t *testing.T) {
 		},
 		{
 			ddl: schemaDefaultValues,
+		},
+		{
+			ddl: schemaChangeStream,
 		},
 	}
 


### PR DESCRIPTION
- We would like to use schema file in `schema` flag with `CREATE CHANGE STREAM` statements.
- So I modified to skip `CREATE CHANGE STREAM` in `ApplyDDL`.