### PR TITLE
add support for JSON type

### DIFF
--- a/server/value.go
+++ b/server/value.go
@@ -520,7 +520,7 @@ func (it *rows) next() ([]interface{}, bool) {
 			values[i] = reflect.New(reflect.TypeOf(sql.NullInt64{}))
 		case TCFloat64:
 			values[i] = reflect.New(reflect.TypeOf(sql.NullFloat64{}))
-		case TCTimestamp, TCDate, TCString:
+		case TCTimestamp, TCDate, TCString, TCJson:
 			values[i] = reflect.New(reflect.TypeOf(sql.NullString{}))
 		case TCBytes:
 			values[i] = reflect.New(reflect.TypeOf(&[]byte{}))
@@ -669,6 +669,8 @@ func makeSpannerTypeFromValueType(typ ValueType) *spannerpb.Type {
 		code = spannerpb.TypeCode_ARRAY
 	case TCStruct:
 		code = spannerpb.TypeCode_STRUCT
+	case TCJson:
+		code = spannerpb.TypeCode_JSON
 	}
 
 	st := &spannerpb.Type{Code: code}
@@ -759,6 +761,10 @@ func makeValueTypeFromSpannerType(typ *spannerpb.Type) (ValueType, error) {
 				FieldNames: names,
 				FieldTypes: types,
 			},
+		}, nil
+	case spannerpb.TypeCode_JSON:
+		return ValueType{
+			Code: TCJson,
 		}, nil
 	}
 
@@ -1027,7 +1033,7 @@ func makeDataFromSpannerValue(key string, v *structpb.Value, typ ValueType) (int
 			return s, nil
 		}
 
-	case TCString:
+	case TCString, TCJson:
 		switch vv := v.Kind.(type) {
 		case *structpb.Value_StringValue:
 			return vv.StringValue, nil

--- a/server/value_test.go
+++ b/server/value_test.go
@@ -299,6 +299,13 @@ func TestDatabaseEncDec(t *testing.T) {
 			},
 			expected: makeTestArray(TCBytes, []byte("xyz"), []byte("xxx")),
 		},
+		"JSON": {
+			value: makeStringValue(`{"a": 1, "b": 2}`),
+			typ: ValueType{
+				Code: TCJson,
+			},
+			expected: `{"a": 1, "b": 2}`,
+		},
 	}
 
 	uuid := uuidpkg.New().String()
@@ -720,6 +727,18 @@ func TestMakeValueFromSpannerValue(t *testing.T) {
 					ArrayType: &ValueType{
 						Code: TCBytes,
 					},
+				},
+			},
+		},
+		"JSON": {
+			value: makeStringValue(`{"a": 1, "b": 2}`),
+			typ: &spannerpb.Type{
+				Code: spannerpb.TypeCode_JSON,
+			},
+			expected: Value{
+				Data: `{"a": 1, "b": 2}`,
+				Type: ValueType{
+					Code: TCJson,
 				},
 			},
 		},


### PR DESCRIPTION
Currently JSON column is not supported. This PR is a follow up for #96 and allows to store and select JSON types as scalars