### PR TITLE
Implement InternalUpdateGraphOperation method

### DIFF
--- a/server/server.go
+++ b/server/server.go
@@ -63,6 +63,11 @@ type server struct {
 	sessions  map[string]*session
 }
 
+func (s *server) InternalUpdateGraphOperation(ctx context.Context, req *adminv1pb.InternalUpdateGraphOperationRequest) (*adminv1pb.InternalUpdateGraphOperationResponse, error) {
+	// Fixes compatibility issue
+	return nil, status.Errorf(codes.Unimplemented, "not implemented yet: InternalUpdateGraphOperation")
+}
+
 func (s *server) ApplyDDL(ctx context.Context, databaseName string, stmt ast.DDL) error {
 	db, err := s.getOrCreateDatabase(databaseName)
 	if err != nil {


### PR DESCRIPTION
Added InternalUpdateGraphOperation method with unimplemented status.

Services are currently seeing errors like this when upgrading to a newer version of `cloud.google.com/go/spanner/*`

```go
../../go/pkg/mod/github.com/gcpug/handy-spanner@v0.7.9/server/server.go:49:9: cannot use &server{…} (value of type *server) as FakeSpannerServer value in return statement: *server does not implement FakeSpannerServer (missing method InternalUpdateGraphOperation)
```