### PR TITLE
Embed unimplemented Server structs for interface updates

### DIFF
--- a/server/server.go
+++ b/server/server.go
@@ -63,7 +63,7 @@ type server struct {
 	sessions  map[string]*session
 
 	// Embed the unimplemented Server structs to avoid having to update the server 
-	// implementation whenever there is an addition to any of the the three interfaces.
+	// implementation whenever there is an addition to any of the three interfaces.
 	spannerpb.UnimplementedSpannerServer
 	adminv1pb.UnimplementedDatabaseAdminServer
 	lropb.UnimplementedOperationsServer

--- a/server/server.go
+++ b/server/server.go
@@ -61,6 +61,12 @@ type server struct {
 
 	sessionMu sync.RWMutex
 	sessions  map[string]*session
+
+	// Embed the unimplemented Server structs to avoid having to update the server 
+	// implementation whenever there is an addition to any of the the three interfaces.
+	spannerpb.UnimplementedSpannerServer
+	adminv1pb.UnimplementedDatabaseAdminServer
+	lropb.UnimplementedOperationsServer
 }
 
 func (s *server) ApplyDDL(ctx context.Context, databaseName string, stmt ast.DDL) error {


### PR DESCRIPTION
The `server` struct fails to implement the `FakeSpannerServer` interface at times because of additions in any of the three embedded interfaces in it.

This PR adds the Unimplemented Servers for respective interfaces in `server` struct, to avoid having to manually update the server implementation with empty function implementation